### PR TITLE
Fix exception namespace.

### DIFF
--- a/src/Context/RawContext.php
+++ b/src/Context/RawContext.php
@@ -130,7 +130,7 @@ class RawContext extends RawMinkContext
 
         $backtrace = debug_backtrace();
 
-        throw new RuntimeException(
+        throw new \RuntimeException(
             'Timeout thrown by ' . $backtrace[1]['class'] . '::' . $backtrace[1]['function']
         );
     }


### PR DESCRIPTION
In current state it is throwing `Fatal error: Class 'Comicrelief\Behat\Context\RuntimeException' not found (Behat\Testwork\Call\Exception\FatalThrowableError)`

