### PR TITLE
GP-1352 Handle request exception in case of GET request

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -93,15 +93,15 @@ class RestContext implements Context
 
         $this->requestUrl = $baseUrl . $pageUrl;
 
-        switch (strtoupper($requestMethod)) {
-            case 'GET':
-                $this->_response = $this->_client->get(
-                    $this->requestUrl . '?' . http_build_query((array)$this->restObject),
-                    $this->requestOptions
-                );
-                break;
-            case 'POST':
-                try {
+        try {
+            switch (strtoupper($requestMethod)) {
+                case 'GET':
+                    $this->_response = $this->_client->get(
+                        $this->requestUrl . '?' . http_build_query((array)$this->restObject),
+                        $this->requestOptions
+                    );
+                    break;
+                case 'POST':
                     $this->_response = $this->_client->post(
                         $this->requestUrl,
                         [
@@ -110,16 +110,16 @@ class RestContext implements Context
                             'verify' => false
                         ]
                     );
-                } catch (RequestException $e) {
-                    $this->_response = $e->getResponse();
-                }
-                break;
-            case 'DELETE':
-                $this->_response = $this->_client->delete(
-                    $this->requestUrl . '?' . http_build_query((array)$this->restObject),
-                    $this->requestOptions
-                );
-                break;
+                    break;
+                case 'DELETE':
+                    $this->_response = $this->_client->delete(
+                        $this->requestUrl . '?' . http_build_query((array)$this->restObject),
+                        $this->requestOptions
+                    );
+                    break;
+            }
+        } catch (RequestException $e) {
+            $this->_response = $e->getResponse();
         }
     }
 


### PR DESCRIPTION
**Type**: patch

Fixes # GP-1352

## Changes proposed in this PR

- Briefly describe the changes in this PR
  - In case a get request returned 404, an exception would be thrown, although, we would expect a valid 404 response instead
  - it was already handled in POST type
